### PR TITLE
Fix: Add no mips32r2 attriute

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,12 +2,21 @@
 target = "mipsel-unknown-none"
 
 [target.mipsel-unknown-none]
-# qemu-system-mipsel -cpu 4Kc -m 64 -nographic -M malta -no-reboot -kernel 
 runner = "qemu-system-mipsel -cpu 4Kc -m 64 -nographic -M malta -no-reboot -kernel"
 rustflags = [
     "-C", "link-arg=-Tsrc/kernel.ld",
     "-C", "force-frame-pointers=yes",
+    "-C", "llvm-args=--debugger-tune=gdb -mattr=+noabicalls",
+    "-C", "target-feature=-mips32r2",
 ]
 
 [unstable]
 build-std = ["core", "compiler_builtins", "alloc"]
+
+[profile.dev]
+opt-level = 0
+debug = true
+
+[profile.release]
+opt-level = 2
+debug = false


### PR DESCRIPTION
Fixes #7 

检查发现编译器会生成指令`seb`
![image](https://github.com/MOS-Rust/kernel/assets/68013339/b45d9ad4-d2c4-4236-923b-6bb5ba4cd07d)

根据指令集和4kc文档，该指令仅在支持mips32r2指令集的处理器上工作，4Kc不支持这样的指令集
![image](https://github.com/MOS-Rust/kernel/assets/68013339/001e9b3b-0529-4cf6-9e40-0f2d5cb61b0f)

编译命令增加 `    "-C", "target-feature=-mips32r2"` 后问题解决