### PR TITLE
Fix: Fixed a bug where print_char only supports one-byte character

### DIFF
--- a/src/platform/qemu/machine.rs
+++ b/src/platform/qemu/machine.rs
@@ -17,7 +17,11 @@ pub fn print_char(c: char) {
     }
     unsafe {
         while read_byte(KSEG1 + SERIAL_LSR) & SERIAL_THR_EMPTY == 0 {}
-        write_byte(KSEG1 + SERIAL_DATA, c as u8);
+        let mut buf = [0; 4];
+        c.encode_utf8(&mut buf);
+        for byte in buf {
+            write_byte(KSEG1 + SERIAL_DATA, byte);
+        }
     }
 }
 


### PR DESCRIPTION
To test the changes:
``` Rust
println!(“你好，世界”);
```